### PR TITLE
added ContentMode = UIViewContentMode.Redraw;

### DIFF
--- a/iOS/ShapeRenderer.cs
+++ b/iOS/ShapeRenderer.cs
@@ -16,6 +16,7 @@ namespace DrawShape.iOS
 
 		public ShapeRenderer ()
 		{
+			ContentMode = UIViewContentMode.Redraw;
 		}
 
 		public override void Draw (System.Drawing.RectangleF rect)


### PR DESCRIPTION
When using the shape view (box shape with rounded corners) in a list view the shape view does not get rendered correctly upon cell reuse. This is a race condition that happens occasionally and the quick and dirty fix is to just set the views ContentMode property to Redraw.
